### PR TITLE
Changed config/locales/zh.yml to correctly identify language

### DIFF
--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,4 +1,4 @@
-en:
+zh:
   label_click_to_enlarge_reduce: "点击放大/缩小"
   label_estimated_speed: "估计速率"
   label_f_day: "%{value}天"


### PR DESCRIPTION
Otherwise plugin labels inevitable switch to chinese if English is selected